### PR TITLE
Update trunking_recorder_handler.py

### DIFF
--- a/lib/trunking_recorder_handler.py
+++ b/lib/trunking_recorder_handler.py
@@ -53,7 +53,7 @@ def create_meta_data(config_data, system_name: str, call_data: dict, audio_wav_p
         "apiKey": "",
         "callAudioFormat": "wav",
         "recordedCall": {
-            "callText": "",
+            "callText": None,
             "talkGroupInfo": {},
             "startTime": "",
             "callDuration": 0,


### PR DESCRIPTION
Changed callText from empty string to None. This is needed so Trunking Recorder will transcribe the call if it is configured to do so